### PR TITLE
Only conditionally uninstall shorewall prior to installing it anew

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,14 +17,19 @@
     name: "{{ item }}"
     state: absent
   with_items:
-    - shorewall
     - iptables-service
+
+- name: "remove other firewall package if shorewall != {{ shorewall_package_name}}"
+  package:
+    name: "shorewall"
+    state: absent
+  when: shorewall_package_name != "shorewall"
 
 - name: install shorewall
   package:
     name: "{{ shorewall_package_name }}"
     state: latest
-  notify: 
+  notify:
     - enabled shorewall
     - start shorewall
   tags:
@@ -58,7 +63,7 @@
     owner: root
     group: root
     mode: 0640
-  notify: 
+  notify:
     - restart shorewall
   tags:
     - configuration
@@ -68,7 +73,7 @@
     package:
       name: "{{ shorewall6_package_name }}"
       state: latest
-    notify: 
+    notify:
       - enabled shorewall6
       - start shorewall6
     tags:


### PR DESCRIPTION
In the current version, the main task first uninstalls shorewall and iptables-service, and then proceeds to install shorewall again (Debian here). This causes unnecessary noise on subsequent installs, as the shorewall package will flip-flop between uninstalled and installed states.

This PR makes the removal of the "shorewall" package contingent on the platform's official 'shorewall' package to be different; in practice, shorewall is installed on first deployment only (like was the case for shorewall6 already)