### PR TITLE
Sort shorewall.conf items to ensure idempotence between runs

### DIFF
--- a/templates/shorewall/shorewall.conf.j2
+++ b/templates/shorewall/shorewall.conf.j2
@@ -8,6 +8,6 @@
 #  Manpage also online at http://www.shorewall.net/manpages/shorewall.conf.html
 ###############################################################################
 
-{% for key,value in shorewall_conf.items() %}
+{% for key,value in shorewall_conf.items()|sort %}
 {{ key|upper }}={{ value }}
 {% endfor %}

--- a/templates/shorewall6/shorewall6.conf.j2
+++ b/templates/shorewall6/shorewall6.conf.j2
@@ -9,6 +9,6 @@
 #  http://www.shorewall.net/manpages6/shorewall6.conf.html
 ###############################################################################
 
-{% for key,value in shorewall6_conf.items() %}
+{% for key,value in shorewall6_conf.items()|sort %}
 {{ key|upper }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Because `shorewall_conf.items()` is a Python dict, which is based on hashes, it results changes between runs, hence the resulting file.

This modification sorts the items to ensure every run gives the same results: a file with sorted keys.