### PR TITLE
Enable and start service

### DIFF
--- a/tasks/shorewall.yml
+++ b/tasks/shorewall.yml
@@ -69,6 +69,12 @@
       notify:
         - restart shorewall
 
+    - name: Ensure Shorewall is enabled and started
+      service:
+        name: shorewall
+        state: started
+        enabled: yes
+        use: service
   when: (shorewall_package_state != "absent")
   tags:
     - configuration

--- a/tasks/shorewall6.yml
+++ b/tasks/shorewall6.yml
@@ -69,6 +69,12 @@
       notify:
         - restart shorewall6
 
+    - name: Ensure Shorewall6 is enabled and started
+      service:
+        name: shorewall6
+        state: started
+        enabled: yes
+        use: service
   when: (shorewall6_package_state != "absent")
   tags:
     - configuration


### PR DESCRIPTION
This checks that the services are enabled and started.

`use: service` is set because of https://github.com/ansible/ansible/issues/22303